### PR TITLE
Carpet rule for creating mobs with no AI using spawn eggs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Disables mobs from spawning in the End.
 - Required options: `true`, `false`
 - Categories: `CREATIVE`, `CARPET-ADDONS-NOT-FOUND`
 
-
 ### disableMobSpawningInNether
 
 Disables mobs from spawning in the Nether.
@@ -218,7 +217,7 @@ A spawn egg will spawn a mob with no AI.
 
 - Type: `boolean`
 - Default value: `false`
-- Required optionsL `true`, `false`
+- Required options: `true`, `false`
 - Categories: `FEATURE`, `CREATIVE`, `CARPET-ADDONS-NOT-FOUND`
 
 ### spectatorPlayersUsePortals

--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ Placing blocks on flowers will replace them like grass.
 - Required options: `false`, `one_tall_flowers`, `all_flowers`
 - Categories: `FEATURE`, `SURVIVAL`, `CARPET-ADDONS-NOT-FOUND`
 
+### spawnEggsSpawnMobsWithNoAI
+
+A spawn egg will spawn a mob with no AI.
+
+- Type: `boolean`
+- Default value: `false`
+- Required optionsL `true`, `false`
+- Categories: `FEATURE`, `CREATIVE`, `CARPET-ADDONS-NOT-FOUND`
+
 ### spectatorPlayersUsePortals
 
 Spectator players can go through nether portals, end portals and end gateways.

--- a/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
+++ b/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
@@ -64,6 +64,9 @@ public class CarpetAddonsNotFoundSettings {
   @Rule(categories = { FEATURE, SURVIVAL, CARPET_ADDONS_NOT_FOUND })
   public static ReplaceableFlowersOptions replaceableFlowers = ReplaceableFlowersOptions.FALSE;
 
+  @Rule(categories = { FEATURE, CREATIVE, CARPET_ADDONS_NOT_FOUND })
+  public static boolean spawnEggsSpawnMobsWithNoAI = false;
+
   @Rule(categories = { FEATURE, EXPERIMENTAL, CARPET_ADDONS_NOT_FOUND })
   public static boolean spectatorPlayersUsePortals = false;
 

--- a/src/main/java/carpetaddonsnotfound/mixins/SpawnEggItem_SpawnEggsSpawnMobsWithNoAIMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/SpawnEggItem_SpawnEggsSpawnMobsWithNoAIMixin.java
@@ -1,0 +1,62 @@
+package carpetaddonsnotfound.mixins;
+
+import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.SpawnEggItem;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(SpawnEggItem.class)
+public abstract class SpawnEggItem_SpawnEggsSpawnMobsWithNoAIMixin {
+
+  @SuppressWarnings("unchecked")
+  @Redirect(method = "useOnBlock", at = @At(value = "INVOKE",
+                                            target = "Lnet/minecraft/entity/EntityType;spawnFromItemStack" +
+                                                     "(Lnet/minecraft/server/world/ServerWorld;" +
+                                                     "Lnet/minecraft/item/ItemStack;" +
+                                                     "Lnet/minecraft/entity/player/PlayerEntity;" +
+                                                     "Lnet/minecraft/util/math/BlockPos;" +
+                                                     "Lnet/minecraft/entity/SpawnReason;ZZ)" +
+                                                     "Lnet/minecraft/entity/Entity;"))
+  private <T extends Entity> T maybeDisableMobAiForUseOnBlock(EntityType<?> instance, ServerWorld world,
+                                                              @Nullable ItemStack stack, @Nullable PlayerEntity player,
+                                                              BlockPos pos, SpawnReason spawnReason,
+                                                              boolean alignPosition, boolean invertY) {
+    return (T) maybeDisableMobAI(instance, world, stack, player, pos, spawnReason, alignPosition, invertY);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Redirect(method = "use", at = @At(value = "INVOKE",
+                                     target = "Lnet/minecraft/entity/EntityType;spawnFromItemStack" +
+                                              "(Lnet/minecraft/server/world/ServerWorld;" +
+                                              "Lnet/minecraft/item/ItemStack;" +
+                                              "Lnet/minecraft/entity/player/PlayerEntity;" +
+                                              "Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/SpawnReason;" +
+                                              "ZZ)Lnet/minecraft/entity/Entity;"))
+  private <T extends Entity> T maybeDisableMobAiForUse(EntityType<?> instance, ServerWorld world,
+                                                       @Nullable ItemStack stack, @Nullable PlayerEntity player,
+                                                       BlockPos pos, SpawnReason spawnReason, boolean alignPosition,
+                                                       boolean invertY) {
+    return (T) maybeDisableMobAI(instance, world, stack, player, pos, spawnReason, alignPosition, invertY);
+  }
+
+  private Entity maybeDisableMobAI(EntityType<?> instance, ServerWorld world, @Nullable ItemStack stack,
+                                   @Nullable PlayerEntity player, BlockPos pos, SpawnReason spawnReason,
+                                   boolean alignPosition, boolean invertY) {
+    Entity entity = instance.spawnFromItemStack(world, stack, player, pos, spawnReason, alignPosition, invertY);
+    if (CarpetAddonsNotFoundSettings.spawnEggsSpawnMobsWithNoAI && entity instanceof MobEntity mobEntity) {
+      mobEntity.setAiDisabled(true);
+    }
+
+    return entity;
+  }
+}

--- a/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
+++ b/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
@@ -19,6 +19,7 @@
   "carpet.rule.netheritePickaxeInstantMineNetherBricks.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine nether brick type blocks.",
   "carpet.rule.phantomsObeyHostileMobCap.desc": "Phantoms will no longer spawn if the hostile mobcap is full. This is per player.",
   "carpet.rule.replaceableFlowers.desc": "Placing blocks on flowers will replace them like grass.",
+  "carpet.rule.spawnEggsSpawnMobsWithNoAI.desc" : "A spawn egg will spawn a mob with no AI.",
   "carpet.rule.spectatorPlayersUsePortals.desc": "Spectator players can go through nether portals, end portals and end gateways.",
   "carpet.rule.xpBubbleColumnInteraction.desc": "Bubble columns will push or pull XP orb entities like with other entities and items."
 }

--- a/src/main/resources/carpet-addons-not-found.mixins.json
+++ b/src/main/resources/carpet-addons-not-found.mixins.json
@@ -15,6 +15,7 @@
     "PlayerEntity_InstantMineMixin",
     "ServerChunkManager_PhantomsObeyHostileMobCapMixin",
     "ServerPlayerEntity_SpectatorPlayersUsePortalsMixin",
+    "SpawnEggItem_SpawnEggsSpawnMobsWithNoAIMixin",
     "SpawnHelper_disableMobSpawningInMixin",
     "TallFlowerBlock_ReplaceFlowersMixin",
     "accessors.EntityAccessorMixin",


### PR DESCRIPTION
Spawn eggs will now be able to spawn mobs with no AI when the `spawnEggsSpawnMobsWithNoAI` rule is enabled.

Closes #96 