### PR TITLE
Refactor PhantomSpawnerMixin to be more compatible with other mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Phantoms will no longer spawn for creative players.
 
 ### disablePhantomSpawningInMushroomFields
 
-Phantoms will no longer spawn in a mushroom fields biome.
+Phantoms will no longer spawn around a player that is in a mushroom fields biome.
 
 - Type: `boolean`
 - Default value: `false`

--- a/src/main/java/carpetaddonsnotfound/mixins/PhantomSpawnerMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/PhantomSpawnerMixin.java
@@ -1,84 +1,39 @@
 package carpetaddonsnotfound.mixins;
 
-import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
-import carpetaddonsnotfound.helpers.ChunkManagerHelper;
-import carpetaddonsnotfound.mixins.invokers.SpawnHelperInfoInvokerMixin;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.SpawnGroup;
+import carpetaddonsnotfound.phantomspawning.PhantomSpawningHandler;
+import carpetaddonsnotfound.phantomspawning.PhantomSpawningHandlerHelper;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.SpawnHelper;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.spawner.PhantomSpawner;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.disablePhantomSpawningForCreativePlayers;
-import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.phantomsObeyHostileMobCap;
+import java.util.ArrayList;
+import java.util.List;
 
-/**
- * This is originally adapted from the
- * <a href="https://github.com/Lunaar-SMP/lunaar-carpet-addons">lunaar carpet extensions mod</a>.
- * At time of writing this code, the lunaar mod is still in version 1.17 and 1.18 experimental snapshots and I really
- * wanted this functionality for 1.19+. If this mod will support versions below 1.19, then only 1.18 will include this
- * carpet rule out of respect for the lunaar mod.
- * <p>
- * Most of the code here is different to lunaar now, as the mob cap is per player and not global anymore.
- */
 @Mixin(PhantomSpawner.class)
 public abstract class PhantomSpawnerMixin {
   /**
-   * Redirects the isSpectator method of the playerEntity when called in the 'phantomSpawner.spawn' method. This is
-   * called in a loop of all world player entities, and we only want to spawn phantoms around players whose hostile mob
-   * cap is below the required values. This allows us to apply additional checks instead of just whether the player is
-   * in spectator. I did not know any other way of implementing this additional conditional!
+   * Modifies the list of {@link PlayerEntity}'s which are looped through when attempting to spawn phantoms. The
+   * returned list will be the ones which this mod determines can have phantoms spawn around.
    *
    * @param instance
-   *         the player instance to check
+   *         the current {@link ServerWorld}
    *
-   * @return true if the player is in spectator mode or the player hostile mob cap is reached.
+   * @return the list of {@link PlayerEntity}'s which can have phantoms spawn around, according to the mod anyway!
    */
-  @Redirect(
-          method = "spawn",
-          at = @At(
-                  value = "INVOKE",
-                  target = "Lnet/minecraft/entity/player/PlayerEntity;isSpectator()Z"
-          )
-  )
-  private boolean isSpectatorCreativeOrAtMobCap(PlayerEntity instance) {
-    boolean isSpectator = instance.isSpectator();
-    boolean isCreative = disablePhantomSpawningForCreativePlayers && instance.isCreative();
-    if (isSpectator || isCreative) {
-      return true;
+  @Redirect(method = "spawn",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;getPlayers()Ljava/util/List;"))
+  private List<PlayerEntity> getPlayersThatPhantomsCanSpawnAround(ServerWorld instance) {
+    List<PlayerEntity> newList = new ArrayList<>();
+    for (PlayerEntity playerEntity : instance.getPlayers()) {
+      PhantomSpawningHandler phantomSpawningHandler = PhantomSpawningHandlerHelper.getPhantomSpawningHandler();
+      if (phantomSpawningHandler.canSpawnPhantom(playerEntity, instance)) {
+        newList.add(playerEntity);
+      }
     }
-    if (!phantomsObeyHostileMobCap) {
-      return false;
-    }
-    ChunkPos playerChunkPos = instance.getChunkPos();
-    SpawnHelper.Info info = ChunkManagerHelper.getInfo();
-    boolean canSpawn = ((SpawnHelperInfoInvokerMixin) info).invokeIsBelowCap(SpawnGroup.MONSTER, playerChunkPos);
-    return !canSpawn;
-  }
 
-  @Redirect(
-          method = "spawn",
-          at = @At(
-                  value = "INVOKE",
-                  target = "Lnet/minecraft/server/world/ServerWorld;spawnEntityAndPassengers" +
-                           "(Lnet/minecraft/entity/Entity;)V"
-          )
-  )
-  private void isInMushroomFieldsBiome(ServerWorld instance, Entity entity) {
-    BlockPos pos = entity.getBlockPos();
-    RegistryEntry<Biome> registryEntry = instance.getBiome(pos);
-    if (!CarpetAddonsNotFoundSettings.disablePhantomSpawningInMushroomFields ||
-        registryEntry.getKey().get() != BiomeKeys.MUSHROOM_FIELDS) {
-      instance.spawnNewEntityAndPassengers(entity);
-    }
+    return newList;
   }
 }

--- a/src/main/java/carpetaddonsnotfound/mixins/ServerChunkManager_PhantomsObeyHostileMobCapMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/ServerChunkManager_PhantomsObeyHostileMobCapMixin.java
@@ -1,6 +1,5 @@
 package carpetaddonsnotfound.mixins;
 
-import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
 import carpetaddonsnotfound.helpers.ChunkManagerHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerChunkManager;
@@ -34,9 +33,9 @@ public abstract class ServerChunkManager_PhantomsObeyHostileMobCapMixin {
           SpawnHelper.ChunkSource chunkSource,
           SpawnDensityCapper densityCapper) {
     SpawnHelper.Info info = SpawnHelper.setupSpawn(spawningChunkCount, entities, chunkSource, densityCapper);
-    if (CarpetAddonsNotFoundSettings.phantomsObeyHostileMobCap) {
-      ChunkManagerHelper.setInfo(info);
-    }
+    // Need to set the info to allow it to be accessed by the ObeyHostileMobCap phantom spawning handler.
+    // If we don't set this on all invocations of this method, then a null pointer exception is thrown.
+    ChunkManagerHelper.setInfo(info);
     return info;
   }
 }

--- a/src/main/java/carpetaddonsnotfound/phantomspawning/DefaultHandler.java
+++ b/src/main/java/carpetaddonsnotfound/phantomspawning/DefaultHandler.java
@@ -1,0 +1,39 @@
+package carpetaddonsnotfound.phantomspawning;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * The default phantom spawning handler. This is always the default set "next" handler for any "proper" implementation.
+ * Avoids annoying null checks in {@link PhantomSpawningHandler#canSpawnPhantom(PlayerEntity, ServerWorld)} method
+ * implementations.
+ *
+ * @author Gilly7CE
+ * @see PhantomSpawningHandler
+ */
+public final class DefaultHandler implements PhantomSpawningHandler {
+  /**
+   * {@inheritDoc} This method is illegal in this implementation. Do not call it!
+   *
+   * @throws UnsupportedOperationException
+   */
+  @Override
+  public PhantomSpawningHandler setNextHandler(PhantomSpawningHandler nextHandler) {
+    throw new UnsupportedOperationException("It is illegal to set a 'next' handler!");
+  }
+
+  /**
+   * Determines whether a phantom can spawn around the player
+   *
+   * @param playerEntity
+   *         the player entity to conditionally spawn the phantom around
+   * @param world
+   *         the current minecraft world.
+   *
+   * @return true since this is always the last handler called in the chain.
+   */
+  @Override
+  public boolean canSpawnPhantom(PlayerEntity playerEntity, ServerWorld world) {
+    return true;
+  }
+}

--- a/src/main/java/carpetaddonsnotfound/phantomspawning/DisableForCreativePlayersHandler.java
+++ b/src/main/java/carpetaddonsnotfound/phantomspawning/DisableForCreativePlayersHandler.java
@@ -1,0 +1,46 @@
+package carpetaddonsnotfound.phantomspawning;
+
+import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * The phantom spawning handler for the
+ * {@link carpetaddonsnotfound.CarpetAddonsNotFoundSettings#disablePhantomSpawningForCreativePlayers} rule.
+ *
+ * @author Gilly7CE
+ * @see PhantomSpawningHandler
+ */
+public final class DisableForCreativePlayersHandler implements PhantomSpawningHandler {
+  private PhantomSpawningHandler nextHandler = new DefaultHandler();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PhantomSpawningHandler setNextHandler(PhantomSpawningHandler nextHandler) {
+    this.nextHandler = nextHandler;
+    return this.nextHandler;
+  }
+
+  /**
+   * Determines whether a phantom can spawn around the player
+   *
+   * @param playerEntity
+   *         the player entity to conditionally spawn the phantom around
+   * @param world
+   *         the current minecraft world.
+   *
+   * @return false if the player entity is in creative mode and
+   * {@link carpetaddonsnotfound.CarpetAddonsNotFoundSettings#disablePhantomSpawningForCreativePlayers} rule is enabled,
+   * otherwise it is passed to next handler which could return true or false.
+   */
+  @Override
+  public boolean canSpawnPhantom(PlayerEntity playerEntity, ServerWorld world) {
+    if (CarpetAddonsNotFoundSettings.disablePhantomSpawningForCreativePlayers && playerEntity.isCreative()) {
+      return false;
+    }
+
+    return this.nextHandler.canSpawnPhantom(playerEntity, world);
+  }
+}

--- a/src/main/java/carpetaddonsnotfound/phantomspawning/DisableInMushroomFieldsHandler.java
+++ b/src/main/java/carpetaddonsnotfound/phantomspawning/DisableInMushroomFieldsHandler.java
@@ -1,0 +1,55 @@
+package carpetaddonsnotfound.phantomspawning;
+
+import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeKeys;
+
+/**
+ * The phantom spawning handler for the
+ * {@link carpetaddonsnotfound.CarpetAddonsNotFoundSettings#disablePhantomSpawningInMushroomFields} rule.
+ *
+ * @author Gilly7CE
+ * @see PhantomSpawningHandler
+ */
+public final class DisableInMushroomFieldsHandler implements PhantomSpawningHandler {
+  private PhantomSpawningHandler nextHandler = new DefaultHandler();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PhantomSpawningHandler setNextHandler(PhantomSpawningHandler nextHandler) {
+    this.nextHandler = nextHandler;
+    return this.nextHandler;
+  }
+
+  /**
+   * Determines whether a phantom can spawn around the player
+   *
+   * @param playerEntity
+   *         the player entity to conditionally spawn the phantom around
+   * @param world
+   *         the current minecraft world.
+   *
+   * @return false if the player entity is in a mushroom fields biome and
+   * {@link carpetaddonsnotfound.CarpetAddonsNotFoundSettings#disablePhantomSpawningInMushroomFields} rule is enabled,
+   * otherwise it is passed to next handler which could return true or false.
+   */
+  @Override
+  public boolean canSpawnPhantom(PlayerEntity playerEntity, ServerWorld world) {
+    BlockPos pos = playerEntity.getBlockPos();
+    RegistryEntry<Biome> registryEntry = world.getBiome(pos);
+    RegistryKey<Biome> biomePlayerIsIn = registryEntry.getKey().orElse(null);
+    if (CarpetAddonsNotFoundSettings.disablePhantomSpawningInMushroomFields &&
+        biomePlayerIsIn == BiomeKeys.MUSHROOM_FIELDS) {
+      return false;
+    }
+
+    return this.nextHandler.canSpawnPhantom(playerEntity, world);
+  }
+}

--- a/src/main/java/carpetaddonsnotfound/phantomspawning/ObeyHostileMobCapHandler.java
+++ b/src/main/java/carpetaddonsnotfound/phantomspawning/ObeyHostileMobCapHandler.java
@@ -1,0 +1,54 @@
+package carpetaddonsnotfound.phantomspawning;
+
+import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
+import carpetaddonsnotfound.helpers.ChunkManagerHelper;
+import carpetaddonsnotfound.mixins.invokers.SpawnHelperInfoInvokerMixin;
+import net.minecraft.entity.SpawnGroup;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.SpawnHelper;
+
+/**
+ * The phantom spawning handler for the
+ * {@link carpetaddonsnotfound.CarpetAddonsNotFoundSettings#phantomsObeyHostileMobCap} rule.
+ *
+ * @author Gilly7CE
+ * @see PhantomSpawningHandler
+ */
+public final class ObeyHostileMobCapHandler implements PhantomSpawningHandler {
+  private PhantomSpawningHandler nextHandler = new DefaultHandler();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public PhantomSpawningHandler setNextHandler(PhantomSpawningHandler nextHandler) {
+    this.nextHandler = nextHandler;
+    return this.nextHandler;
+  }
+
+  /**
+   * Determines whether a phantom can spawn around the player
+   *
+   * @param playerEntity
+   *         the player entity to conditionally spawn the phantom around
+   * @param world
+   *         the current minecraft world.
+   *
+   * @return false if the mobcap around the player entity is full and
+   * {@link carpetaddonsnotfound.CarpetAddonsNotFoundSettings#phantomsObeyHostileMobCap} rule is enabled, otherwise it
+   * is passed to next handler which could return true or false.
+   */
+  @Override
+  public boolean canSpawnPhantom(PlayerEntity playerEntity, ServerWorld world) {
+    ChunkPos playerChunkPos = playerEntity.getChunkPos();
+    SpawnHelper.Info info = ChunkManagerHelper.getInfo();
+    boolean isMobCapFull = !((SpawnHelperInfoInvokerMixin) info).invokeIsBelowCap(SpawnGroup.MONSTER, playerChunkPos);
+    if (CarpetAddonsNotFoundSettings.phantomsObeyHostileMobCap && isMobCapFull) {
+      return false;
+    }
+
+    return this.nextHandler.canSpawnPhantom(playerEntity, world);
+  }
+}

--- a/src/main/java/carpetaddonsnotfound/phantomspawning/PhantomSpawningHandler.java
+++ b/src/main/java/carpetaddonsnotfound/phantomspawning/PhantomSpawningHandler.java
@@ -1,0 +1,40 @@
+package carpetaddonsnotfound.phantomspawning;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * Defines a handler which determines whether a phantom can spawn or not. This uses the chain of responsibility pattern
+ * to allow chaining several handlers together in a deterministic order. It also allows for decoupling different phantom
+ * spawning rules from each other instead of extending the mixin for PhantomSpawner.
+ *
+ * @author Gilly7CE
+ * @see net.minecraft.world.spawner.PhantomSpawner
+ * @see carpetaddonsnotfound.mixins.PhantomSpawnerMixin
+ */
+public interface PhantomSpawningHandler {
+  /**
+   * Sets the next handler in the chain.
+   *
+   * @param nextHandler
+   *         the handler which will be processed next in the chain if this handler can allow phantom spawning.
+   *
+   * @return the passed in handler. This allows chaining calls to this method together.
+   */
+  PhantomSpawningHandler setNextHandler(PhantomSpawningHandler nextHandler);
+
+  /**
+   * Determines whether a phantom should spawn or not. This is the method which "handles the request".
+   *
+   * @param playerEntity
+   *         the player entity to conditionally spawn the phantom around
+   * @param world
+   *         the current minecraft world.
+   *
+   * @return true if we can spawn a phantom, otherwise false.
+   *
+   * @implNote if the implementation method determines that the phantom can spawn, then it should pass the check to the
+   * next handler. It should return immediately if the phantom cannot spawn.
+   */
+  boolean canSpawnPhantom(PlayerEntity playerEntity, ServerWorld world);
+}

--- a/src/main/java/carpetaddonsnotfound/phantomspawning/PhantomSpawningHandlerHelper.java
+++ b/src/main/java/carpetaddonsnotfound/phantomspawning/PhantomSpawningHandlerHelper.java
@@ -20,9 +20,9 @@ public class PhantomSpawningHandlerHelper {
   }
 
   private static PhantomSpawningHandler createPhantomSpawningHandler() {
-    var disableForCreativePlayersHandler = new DisableForCreativePlayersHandler();
-    var disableInMushroomFieldsHandler = new DisableInMushroomFieldsHandler();
-    var obeyHostileMobCapHandler = new ObeyHostileMobCapHandler();
+    DisableForCreativePlayersHandler disableForCreativePlayersHandler = new DisableForCreativePlayersHandler();
+    DisableInMushroomFieldsHandler disableInMushroomFieldsHandler = new DisableInMushroomFieldsHandler();
+    ObeyHostileMobCapHandler obeyHostileMobCapHandler = new ObeyHostileMobCapHandler();
 
     disableForCreativePlayersHandler.setNextHandler(disableInMushroomFieldsHandler)
                                     .setNextHandler(obeyHostileMobCapHandler);

--- a/src/main/java/carpetaddonsnotfound/phantomspawning/PhantomSpawningHandlerHelper.java
+++ b/src/main/java/carpetaddonsnotfound/phantomspawning/PhantomSpawningHandlerHelper.java
@@ -1,0 +1,32 @@
+package carpetaddonsnotfound.phantomspawning;
+
+/**
+ * Helper class for {@link PhantomSpawningHandler}. Allows callers to use the interface without caring about its
+ * implementation.
+ *
+ * @author Gilly7CE
+ * @see PhantomSpawningHandler
+ */
+public class PhantomSpawningHandlerHelper {
+  private static final PhantomSpawningHandler phantomSpawningHandler = createPhantomSpawningHandler();
+
+  /**
+   * Returns the {@link PhantomSpawningHandler} for the mod.
+   *
+   * @return {@link PhantomSpawningHandler}
+   */
+  public static PhantomSpawningHandler getPhantomSpawningHandler() {
+    return phantomSpawningHandler;
+  }
+
+  private static PhantomSpawningHandler createPhantomSpawningHandler() {
+    var disableForCreativePlayersHandler = new DisableForCreativePlayersHandler();
+    var disableInMushroomFieldsHandler = new DisableInMushroomFieldsHandler();
+    var obeyHostileMobCapHandler = new ObeyHostileMobCapHandler();
+
+    disableForCreativePlayersHandler.setNextHandler(disableInMushroomFieldsHandler)
+                                    .setNextHandler(obeyHostileMobCapHandler);
+
+    return disableForCreativePlayersHandler;
+  }
+}

--- a/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
+++ b/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
@@ -5,7 +5,7 @@
   "carpet.rule.disableMobSpawningInNether.desc": "Disables mobs from spawning in the Nether",
   "carpet.rule.disableMobSpawningInOverworld.desc": "Disables mobs from spawning in the Overworld",
   "carpet.rule.disablePhantomSpawningForCreativePlayers.desc": "Phantoms will no longer spawn for creative players.",
-  "carpet.rule.disablePhantomSpawningInMushroomFields.desc": "Phantoms will no longer spawn in a mushroom fields biome.",
+  "carpet.rule.disablePhantomSpawningInMushroomFields.desc": "Phantoms will no longer spawn around a player that is in a mushroom fields biome.",
   "carpet.rule.dispensersPlaceEyesOfEnder.desc": "Dispensers can place eyes of ender into end portal frames.",
   "carpet.rule.dispensersRemoveEyesOfEnder.desc": "Dispensers can remove eyes of ender from full end portal frames. Any connecting end portals will break.",
   "carpet.rule.dropEyesOfEnderFromEndPortalFrame.desc": "A full end portal frame will drop an eye of ender when right clicked by a player, turning into an empty end portal frame in the process. Any connecting end portals will break.",


### PR DESCRIPTION
`PhantomSpawnerMixin` was failing to load due to incompatibility with [essential addons](https://github.com/Super-Santa/EssentialAddons). It has its own mixin redirect targeting the same method we were. Refactoring our code for our phantom spawning rules has now allowed us to target the direct invocation of `ServerWorld.getPlayers` and prevent any loop for a player where our phantom spawning rules determine it should be disabled. This is still a redirect, but hopefully will mean being more compatible with other mods. The refactoring also allows us to more easily change this mixin in the future if another issue crops up, and makes it more extensible to other "disabling" type rules we might introduce for phantoms.

The refactored code leverages the "chain of responsibility" pattern to determine whether phantoms should spawn around a particular player. Each "handler" checks whether the player meets its specific conditions for its corresponding rule. If the handler finds the phantoms should not spawn then the chain is broken and no phantoms shall spawn around the player. The order of this chain is as follows (expressed as the carpet rules):
- `disablePhantomSpawningForCreativePlayers`
- `disablePhantomSpawningInMushroomFields`
- `phantomsObeyHostileMobCap`

This order has been chosen based on the priority each rule should have.

Fixes #123 