### PR TITLE
Fix `spectatorPlayersUsePortals` not showing portal nausea affect when `portalSpectatorDelay` is at a value greater than 1

### DIFF
--- a/src/main/java/carpetaddonsnotfound/fakes/ClientPlayPacketListenerInterface.java
+++ b/src/main/java/carpetaddonsnotfound/fakes/ClientPlayPacketListenerInterface.java
@@ -7,7 +7,7 @@ import carpetaddonsnotfound.network.packets.SpectatorPlayerInPortalBlockS2CPacke
  */
 public interface ClientPlayPacketListenerInterface {
   /**
-   * Called when the server side spectator player entity is inside the
+   * Called when the server side spectator player entity is inside a nether portal block.
    *
    * @param spectatorPlayerInPortalBlockS2CPacket
    *         the packet to send to the client

--- a/src/main/java/carpetaddonsnotfound/fakes/ClientPlayPacketListenerInterface.java
+++ b/src/main/java/carpetaddonsnotfound/fakes/ClientPlayPacketListenerInterface.java
@@ -1,0 +1,16 @@
+package carpetaddonsnotfound.fakes;
+
+import carpetaddonsnotfound.network.packets.SpectatorPlayerInPortalBlockS2CPacket;
+
+/**
+ * Interface which allows extending the {@link net.minecraft.client.network.ClientPlayNetworkHandler} class
+ */
+public interface ClientPlayPacketListenerInterface {
+  /**
+   * Called when the server side spectator player entity is inside the
+   *
+   * @param spectatorPlayerInPortalBlockS2CPacket
+   *         the packet to send to the client
+   */
+  void onSpectatorPlayerInPortalBlock(SpectatorPlayerInPortalBlockS2CPacket spectatorPlayerInPortalBlockS2CPacket);
+}

--- a/src/main/java/carpetaddonsnotfound/mixins/ClientPlayNetworkHandler_SpectatorPlayersUsePortalsMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/ClientPlayNetworkHandler_SpectatorPlayersUsePortalsMixin.java
@@ -1,0 +1,27 @@
+package carpetaddonsnotfound.mixins;
+
+import carpetaddonsnotfound.fakes.ClientPlayPacketListenerInterface;
+import carpetaddonsnotfound.network.packets.SpectatorPlayerInPortalBlockS2CPacket;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.network.ClientPlayerEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public abstract class ClientPlayNetworkHandler_SpectatorPlayersUsePortalsMixin
+        implements ClientPlayPacketListenerInterface {
+  @Final
+  @Shadow
+  private MinecraftClient client;
+
+  @Override
+  public void onSpectatorPlayerInPortalBlock(
+          SpectatorPlayerInPortalBlockS2CPacket spectatorPlayerInPortalBlockS2CPacket) {
+    ClientPlayerEntity playerEntity = client.player;
+    if (playerEntity != null) {
+      playerEntity.setInNetherPortal(spectatorPlayerInPortalBlockS2CPacket.getPortalBlockPos());
+    }
+  }
+}

--- a/src/main/java/carpetaddonsnotfound/mixins/NetworkState_SpectatorPlayersUsePortalsMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/NetworkState_SpectatorPlayersUsePortalsMixin.java
@@ -1,0 +1,21 @@
+package carpetaddonsnotfound.mixins;
+
+import carpetaddonsnotfound.network.packets.SpectatorPlayerInPortalBlockS2CPacket;
+import net.minecraft.network.NetworkState;
+import net.minecraft.network.packet.Packet;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(NetworkState.class)
+public abstract class NetworkState_SpectatorPlayersUsePortalsMixin {
+  @Inject(method = "getPacketHandlerState", at = @At("HEAD"), cancellable = true)
+  private static void getPacketHandlerStateForSpectatorPlayerInPortal(Packet<?> handler,
+                                                                      CallbackInfoReturnable<@Nullable NetworkState> cir) {
+    if (handler instanceof SpectatorPlayerInPortalBlockS2CPacket) {
+      cir.setReturnValue(NetworkState.PLAY);
+    }
+  }
+}

--- a/src/main/java/carpetaddonsnotfound/network/packets/SpectatorPlayerInPortalBlockS2CPacket.java
+++ b/src/main/java/carpetaddonsnotfound/network/packets/SpectatorPlayerInPortalBlockS2CPacket.java
@@ -1,0 +1,29 @@
+package carpetaddonsnotfound.network.packets;
+
+import carpetaddonsnotfound.fakes.ClientPlayPacketListenerInterface;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.listener.ClientPlayPacketListener;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.util.math.BlockPos;
+
+public final class SpectatorPlayerInPortalBlockS2CPacket implements Packet<ClientPlayPacketListener> {
+  private final BlockPos portalBlockPos;
+
+  public SpectatorPlayerInPortalBlockS2CPacket(BlockPos portalBlockPos) {
+    this.portalBlockPos = portalBlockPos;
+  }
+
+  @Override
+  public void write(PacketByteBuf buf) {
+    buf.writeBlockPos(portalBlockPos);
+  }
+
+  @Override
+  public void apply(ClientPlayPacketListener clientPlayPacketListener) {
+    ((ClientPlayPacketListenerInterface) clientPlayPacketListener).onSpectatorPlayerInPortalBlock(this);
+  }
+
+  public BlockPos getPortalBlockPos() {
+    return this.portalBlockPos;
+  }
+}

--- a/src/main/resources/carpet-addons-not-found.mixins.json
+++ b/src/main/resources/carpet-addons-not-found.mixins.json
@@ -3,10 +3,12 @@
   "package": "carpetaddonsnotfound.mixins",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "ClientPlayNetworkHandler_SpectatorPlayersUsePortalsMixin",
     "DispenserBlock_GetCustomBehaviorMixin",
     "EndFrameBlock_EyeToggleMixin",
     "ExperienceOrbEntity_XpBubbleColumnInteractionMixin",
     "FlowerBlock_ReplaceFlowersMixin",
+    "NetworkState_SpectatorPlayersUsePortalsMixin",
     "PhantomSpawnerMixin",
     "PistonBlock_MovableEmptyEndPortalFrameMixin",
     "PistonBlock_MovableSpawnersMixin",


### PR DESCRIPTION
When the server side player entity moves into a nether portal it will now send a packet to the client telling it to set the client side player to be inside a nether portal block. This will then allow the portal nausea animation to play.

Fixes #126 