### PR TITLE
Fix Stonecutter damage not producing damage sound

### DIFF
--- a/src/main/java/carpetaddonsnotfound/mixins/StonecutterBlock_StonecuttersDoDamageMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/StonecutterBlock_StonecuttersDoDamageMixin.java
@@ -6,14 +6,15 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.StonecutterBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.damage.*;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.damage.DamageType;
+import net.minecraft.entity.damage.DamageTypes;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 
 import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.stonecuttersDoDamage;
 
@@ -34,7 +35,8 @@ public abstract class StonecutterBlock_StonecuttersDoDamageMixin extends Block {
       return;
     }
 
-    RegistryEntry<DamageType> type = world.getRegistryManager().get(RegistryKeys.DAMAGE_TYPE).getEntry(DamageTypes.GENERIC).orElseThrow();
+    RegistryEntry<DamageType> type =
+            world.getRegistryManager().get(RegistryKeys.DAMAGE_TYPE).getEntry(DamageTypes.GENERIC).orElseThrow();
     entity.damage(new DamageSource(type, new Vec3d(pos.getX(), pos.getY(), pos.getZ())), stonecuttersDoDamage);
   }
 }

--- a/src/main/java/carpetaddonsnotfound/mixins/StonecutterBlock_StonecuttersDoDamageMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/StonecutterBlock_StonecuttersDoDamageMixin.java
@@ -6,38 +6,35 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.StonecutterBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.damage.DamageEffects;
-import net.minecraft.entity.damage.DamageScaling;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.entity.damage.DamageType;
+import net.minecraft.entity.damage.*;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 
 import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.stonecuttersDoDamage;
 
 @Mixin(StonecutterBlock.class)
 public abstract class StonecutterBlock_StonecuttersDoDamageMixin extends Block {
-  RegistryEntry<DamageType> damageType = new RegistryEntry.Direct<>(
-          new DamageType("stonecutter", DamageScaling.NEVER, 0.1f, DamageEffects.HURT)
-  );
-
   StonecutterBlock_StonecuttersDoDamageMixin(AbstractBlock.Settings settings) {
     super(settings);
   }
 
   @Override
   public void onSteppedOn(World world, BlockPos pos, BlockState state, Entity entity) {
-    if (world.isClient() || !world.isReceivingRedstonePower(pos)) {
+    if (world.isClient() || !world.isReceivingRedstonePower(pos) || stonecuttersDoDamage == 0.0f) {
       return;
     }
+
     if (stonecuttersDoDamage < 0.0f && entity instanceof LivingEntity livingEntity) {
       livingEntity.heal(-stonecuttersDoDamage);
+      return;
     }
-    else if (stonecuttersDoDamage > 0.0f) {
-      entity.damage(new DamageSource(damageType, new Vec3d(pos.getX(), pos.getY(), pos.getZ())), stonecuttersDoDamage);
-    }
+
+    RegistryEntry<DamageType> type = world.getRegistryManager().get(RegistryKeys.DAMAGE_TYPE).getEntry(DamageTypes.GENERIC).orElseThrow();
+    entity.damage(new DamageSource(type, new Vec3d(pos.getX(), pos.getY(), pos.getZ())), stonecuttersDoDamage);
   }
 }


### PR DESCRIPTION
The `DamageType` `RegistryEntry` was a custom one but there is no way to currently register custom `DamageType`'s in Fabric, as there is no dedicated method in the `Registries` class for `DamageType`. The client side resolves a packet which expects the damage type to be registered in the registry. Removed the "stonecutter" custom one in favour of the "GENERIC" version.

Fixes #175 