### PR TITLE
Fix `dropEyesOfEnderFromEndPortalFrame` rule not working on release build

### DIFF
--- a/src/main/java/carpetaddonsnotfound/mixins/EndFrameBlock_EyeToggleMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/EndFrameBlock_EyeToggleMixin.java
@@ -2,6 +2,7 @@ package carpetaddonsnotfound.mixins;
 
 import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
 import carpetaddonsnotfound.helpers.EndPortalFrameHelper;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.EndPortalFrameBlock;
 import net.minecraft.entity.player.PlayerEntity;
@@ -16,15 +17,22 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 import static net.minecraft.block.Block.dropStack;
 
 @Mixin(EndPortalFrameBlock.class)
-public abstract class EndFrameBlock_EyeToggleMixin {
+public abstract class EndFrameBlock_EyeToggleMixin extends Block {
   @Shadow
   @Final
   public static BooleanProperty EYE;
 
+  public EndFrameBlock_EyeToggleMixin(Settings settings) {
+    super(settings);
+  }
+
+  @SuppressWarnings("deprecation") // It gets called by the new method anyway, so we can fix when they actually change it
+  @Override
   public ActionResult onUse(BlockState state,
                             World world,
                             BlockPos pos,

--- a/src/main/java/carpetaddonsnotfound/mixins/EndFrameBlock_EyeToggleMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/EndFrameBlock_EyeToggleMixin.java
@@ -17,9 +17,6 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
-
-import static net.minecraft.block.Block.dropStack;
 
 @Mixin(EndPortalFrameBlock.class)
 public abstract class EndFrameBlock_EyeToggleMixin extends Block {


### PR DESCRIPTION
The `OnUse` method in the mixin would override the method properly in the dev build but in the release build it wouldn't work. Mixin now refactored to extend the `Block` class like its target, and use `@Override` tag to guarantee to work. Also disables a deprecation warning, which we can modify once it is changed for real by Mojang.

I've tested this by building the mod locally and using the .jar file generated with my 1.20.1 client. It now works.

Fixes #181 