### PR TITLE
Add `disableEndSpikeRegen` rule

### DIFF
--- a/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
+++ b/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
@@ -21,6 +21,9 @@ public class CarpetAddonsNotFoundSettings {
   @CarpetAddonsNotFoundRule(categories = { CREATIVE })
   public static boolean disableMobSpawningInOverworld = false;
 
+  @CarpetAddonsNotFoundRule(categories = { FEATURE })
+  public static boolean disableEndSpikeRegen = false;
+
   @CarpetAddonsNotFoundRule(categories = { CREATIVE, FEATURE })
   public static boolean disablePhantomSpawningForCreativePlayers = false;
 

--- a/src/main/java/carpetaddonsnotfound/mixins/EnderDragonFightMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/EnderDragonFightMixin.java
@@ -1,0 +1,39 @@
+package carpetaddonsnotfound.mixins;
+
+import net.minecraft.entity.boss.dragon.EnderDragonFight;
+import net.minecraft.entity.boss.dragon.EnderDragonSpawnState;
+import net.minecraft.entity.decoration.EndCrystalEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.List;
+
+import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.disableEndSpikeRegen;
+import static net.minecraft.entity.boss.dragon.EnderDragonSpawnState.PREPARING_TO_SUMMON_PILLARS;
+import static net.minecraft.entity.boss.dragon.EnderDragonSpawnState.SUMMONING_DRAGON;
+
+@Mixin(EnderDragonFight.class)
+public abstract class EnderDragonFightMixin {
+  @Shadow
+  private EnderDragonSpawnState dragonSpawnState;
+
+  @Redirect(method = "tick",
+            at = @At(value = "INVOKE",
+                     target = "Lnet/minecraft/entity/boss/dragon/EnderDragonSpawnState;run(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/boss/dragon/EnderDragonFight;Ljava/util/List;ILnet/minecraft/util/math/BlockPos;)V"))
+  private void onEnderDragonSpawnStateRun(EnderDragonSpawnState instance,
+                                          ServerWorld serverWorld,
+                                          EnderDragonFight enderDragonFight,
+                                          List<EndCrystalEntity> endCrystalEntities,
+                                          int tick,
+                                          BlockPos blockPos) {
+    // This bypasses the SUMMONING_PILLARS state
+    if (disableEndSpikeRegen && this.dragonSpawnState == PREPARING_TO_SUMMON_PILLARS)
+      this.dragonSpawnState = SUMMONING_DRAGON;
+
+    this.dragonSpawnState.run(serverWorld, enderDragonFight, endCrystalEntities, tick, blockPos);
+  }
+}

--- a/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
+++ b/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
@@ -5,6 +5,7 @@
   "carpet.rule.disableMobSpawningInEnd.desc": "Disables mobs from spawning in the End.",
   "carpet.rule.disableMobSpawningInNether.desc": "Disables mobs from spawning in the Nether.",
   "carpet.rule.disableMobSpawningInOverworld.desc": "Disables mobs from spawning in the Overworld.",
+  "carpet.rule.disableEndSpikeRegen.desc": "Disables the regeneration of the end spike obsidian towers when the ender dragon is respawned.",
   "carpet.rule.disablePhantomSpawningForCreativePlayers.desc": "Phantoms will no longer spawn for creative players.",
   "carpet.rule.disablePhantomSpawningInMushroomFields.desc": "Phantoms will no longer spawn around a player that is in a mushroom fields biome.",
   "carpet.rule.dispensersPlaceEyesOfEnder.desc": "Dispensers can place eyes of ender into end portal frames.",

--- a/src/main/resources/carpet-addons-not-found.mixins.json
+++ b/src/main/resources/carpet-addons-not-found.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "DispenserBlockMixin",
+    "EnderDragonFightMixin",
     "EnderEyeItemMixin",
     "EndermanEntityMixin",
     "ExperienceOrbEntityMixin",


### PR DESCRIPTION
Adds a carpet rule for preventing the end spikes (Obsidian Pillars) in the End from regenerating when respawning the dragon.

Closes #187 