### PR TITLE
Add missing rule observer and validator for `unobtainableBlocksDropAsItems`

### DIFF
--- a/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
+++ b/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
@@ -2,6 +2,7 @@ package carpetaddonsnotfound;
 
 import carpetaddonsnotfound.settings.CarpetAddonsNotFoundRule;
 import carpetaddonsnotfound.validators.RequiresMovableBlockEntities;
+import carpetaddonsnotfound.validators.RequiresMovableEmptyEndPortalFrames;
 
 import static carpetaddonsnotfound.settings.CarpetAddonsNotFoundRuleCategory.*;
 
@@ -93,7 +94,8 @@ public class CarpetAddonsNotFoundSettings {
   //$$ public static int stonecuttersDoDamage = 0;
   //#endif
 
-  @CarpetAddonsNotFoundRule(categories = { FEATURE, EXPERIMENTAL })
+  @CarpetAddonsNotFoundRule(categories = { FEATURE, EXPERIMENTAL },
+                            validators = RequiresMovableEmptyEndPortalFrames.class)
   public static boolean unobtainableBlocksDropAsItems = false;
 
   @CarpetAddonsNotFoundRule(categories = { FEATURE })

--- a/src/main/java/carpetaddonsnotfound/settings/CarpetAddonsNotFoundRuleRegistrar.java
+++ b/src/main/java/carpetaddonsnotfound/settings/CarpetAddonsNotFoundRuleRegistrar.java
@@ -11,7 +11,8 @@ import carpet.api.settings.SettingsManager;
 //$$ import org.jetbrains.annotations.Nullable;
 //$$ import java.util.Map;
 //#endif
-import carpetaddonsnotfound.ruleobservers.MovableBlockEntitiesRuleObserver;
+import carpetaddonsnotfound.settings.ruleobservers.MovableBlockEntitiesRuleObserver;
+import carpetaddonsnotfound.settings.ruleobservers.MovableEmptyEndPortalFramesRuleObserver;
 import com.google.common.collect.Lists;
 
 import java.lang.reflect.Constructor;
@@ -23,7 +24,8 @@ import java.util.List;
 public final class CarpetAddonsNotFoundRuleRegistrar {
   private static boolean hasRegistered = false;
   private static final List<CarpetAddonsNotFoundRuleObserver> ruleObservers = new ArrayList<>(List.of(
-          new MovableBlockEntitiesRuleObserver()));
+          new MovableBlockEntitiesRuleObserver(),
+          new MovableEmptyEndPortalFramesRuleObserver()));
 
   private final SettingsManager settingsManager;
   private final List<ParsedCarpetAddonsNotFoundRule<?>> rules = Lists.newArrayList();

--- a/src/main/java/carpetaddonsnotfound/settings/ruleobservers/MovableBlockEntitiesRuleObserver.java
+++ b/src/main/java/carpetaddonsnotfound/settings/ruleobservers/MovableBlockEntitiesRuleObserver.java
@@ -1,0 +1,32 @@
+package carpetaddonsnotfound.settings.ruleobservers;
+
+import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
+import carpetaddonsnotfound.settings.CarpetAddonsNotFoundRuleObserver;
+import carpetaddonsnotfound.settings.ParsedCarpetAddonsNotFoundRule;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import java.util.Objects;
+
+public final class MovableBlockEntitiesRuleObserver extends CarpetAddonsNotFoundRuleObserver {
+  @Override
+  public void ruleChanged(ServerCommandSource source, ParsedCarpetAddonsNotFoundRule<?> changedRule, String userInput) {
+    // Using a string here directly feels wrong but likelihood of renaming this rule is low
+    if (!Objects.equals(changedRule.name(), "movableBlockEntities")) {
+      return;
+    }
+
+    boolean ruleEnabled = (boolean) changedRule.value();
+    if (ruleEnabled || !CarpetAddonsNotFoundSettings.movableSpawners) {
+      return;
+    }
+
+    source.sendFeedback(
+            //#if MC>11904
+            () ->
+            //#endif
+            Text.of("Warning: disabling `movableSpawners` as it requires `movableBlockEntities` to be enabled"),
+    true);
+    CarpetAddonsNotFoundSettings.movableSpawners = false;
+  }
+}

--- a/src/main/java/carpetaddonsnotfound/settings/ruleobservers/MovableEmptyEndPortalFramesRuleObserver.java
+++ b/src/main/java/carpetaddonsnotfound/settings/ruleobservers/MovableEmptyEndPortalFramesRuleObserver.java
@@ -1,4 +1,4 @@
-package carpetaddonsnotfound.ruleobservers;
+package carpetaddonsnotfound.settings.ruleobservers;
 
 import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
 import carpetaddonsnotfound.settings.CarpetAddonsNotFoundRuleObserver;
@@ -8,16 +8,18 @@ import net.minecraft.text.Text;
 
 import java.util.Objects;
 
-public final class MovableBlockEntitiesRuleObserver extends CarpetAddonsNotFoundRuleObserver {
+import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.MovableBlockOptions;
+
+public final class MovableEmptyEndPortalFramesRuleObserver extends CarpetAddonsNotFoundRuleObserver {
   @Override
   public void ruleChanged(ServerCommandSource source, ParsedCarpetAddonsNotFoundRule<?> changedRule, String userInput) {
     // Using a string here directly feels wrong but likelihood of renaming this rule is low
-    if (!Objects.equals(changedRule.name(), "movableBlockEntities")) {
+    if (!Objects.equals(changedRule.name(), "movableEmptyEndPortalFrames")) {
       return;
     }
 
-    boolean ruleEnabled = (boolean) changedRule.value();
-    if (ruleEnabled || !CarpetAddonsNotFoundSettings.movableSpawners) {
+    boolean ruleEnabled = changedRule.value() != MovableBlockOptions.FALSE;
+    if (ruleEnabled || !CarpetAddonsNotFoundSettings.unobtainableBlocksDropAsItems) {
       return;
     }
 
@@ -25,8 +27,8 @@ public final class MovableBlockEntitiesRuleObserver extends CarpetAddonsNotFound
             //#if MC>11904
             () ->
             //#endif
-            Text.of("Warning: disabling `movableSpawners` as it requires `movableBlockEntities` to be enabled"),
+            Text.of("Warning: disabling `unobtainableBlocksDropAsItems` as it requires `movableEmptyEndPortalFrames` to be enabled"),
     true);
-    CarpetAddonsNotFoundSettings.movableSpawners = false;
+    CarpetAddonsNotFoundSettings.unobtainableBlocksDropAsItems = false;
   }
 }

--- a/src/main/java/carpetaddonsnotfound/validators/RequiresMovableEmptyEndPortalFrames.java
+++ b/src/main/java/carpetaddonsnotfound/validators/RequiresMovableEmptyEndPortalFrames.java
@@ -1,0 +1,25 @@
+package carpetaddonsnotfound.validators;
+
+import carpetaddonsnotfound.CarpetAddonsNotFoundSettings;
+import carpetaddonsnotfound.settings.CarpetAddonsNotFoundRuleValidator;
+import carpetaddonsnotfound.settings.ParsedCarpetAddonsNotFoundRule;
+import net.minecraft.server.command.ServerCommandSource;
+
+public final class RequiresMovableEmptyEndPortalFrames extends CarpetAddonsNotFoundRuleValidator<Boolean> {
+  @Override
+  public Boolean validate(ServerCommandSource source,
+                          ParsedCarpetAddonsNotFoundRule<Boolean> rule,
+                          Boolean newValue,
+                          String string) {
+    if (newValue && CarpetAddonsNotFoundSettings.movableEmptyEndPortalFrames == CarpetAddonsNotFoundSettings.MovableBlockOptions.FALSE) {
+      return null; // Setting to true whilst movableEmptyEndPortalFrames is false is illegal!
+    }
+
+    return newValue;
+  }
+
+  @Override
+  public String description() {
+    return "This requires the `movableEmptyEndPortalFrames` carpet rule to be enabled.";
+  }
+}


### PR DESCRIPTION
Adds the missing rule observer and validator for `unobtainableBlocksDropAsItems` which were excluded from #229. Needed to ensure the rules aren't used in an improper state.

Closes #214 