### PR TITLE
Add `beeBreedingCooldown` carpet rule

### DIFF
--- a/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
+++ b/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
@@ -10,6 +10,9 @@ public class CarpetAddonsNotFoundSettings {
   @CarpetAddonsNotFoundRule(categories = { FEATURE })
   public static boolean alwaysPickFlowersFromPots = false;
 
+  @CarpetAddonsNotFoundRule(categories = { FEATURE, SURVIVAL }, strict = false, options = { "0", "600", "1200", "6000", "12000"})
+  public static int beeBreedingCooldown = 6000;
+
   @CarpetAddonsNotFoundRule(categories = { FEATURE, CREATIVE })
   public static boolean creativePlayerOneHitKill = false;
 

--- a/src/main/java/carpetaddonsnotfound/mixins/AnimalEntityMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/AnimalEntityMixin.java
@@ -1,0 +1,55 @@
+package carpetaddonsnotfound.mixins;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.passive.BeeEntity;
+import net.minecraft.entity.passive.PassiveEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+//#if MC<12002
+//$$ import com.llamalad7.mixinextras.sugar.Local;
+//#endif
+
+import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.beeBreedingCooldown;
+
+@Mixin(AnimalEntity.class)
+public abstract class AnimalEntityMixin extends PassiveEntity {
+
+  protected AnimalEntityMixin(EntityType<? extends PassiveEntity> entityType,
+                              World world) {
+    super(entityType, world);
+  }
+
+  @Inject(method = "breed(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/passive/AnimalEntity;" +
+                   //#if MC>11904
+                   "Lnet/minecraft/entity/passive/PassiveEntity;" +
+                   //#endif
+                   ")V",
+          at = @At(value = "TAIL"))
+  private void setBeesBreedingAge(ServerWorld world,
+                                  AnimalEntity other,
+                                  //#if MC>11904
+                                  PassiveEntity baby,
+                                  //#endif
+                                  CallbackInfo ci
+                                  //#if MC<12002
+                                  //$$ , @Local PassiveEntity passiveEntity
+                                  //#endif
+  ) {
+    boolean canSetBreedingAge =
+            //#if MC<12002
+            //$$ passiveEntity != null &&
+            //#endif
+            other instanceof BeeEntity;
+    if (!canSetBreedingAge)
+      return;
+
+    this.setBreedingAge(beeBreedingCooldown);
+    other.setBreedingAge(beeBreedingCooldown);
+  }
+}

--- a/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
+++ b/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "carpet.category.carpet_addons_not_found": "carpet-addons-not-found",
   "carpet.rule.alwaysPickFlowersFromPots.desc": "Right-clicking on a flowerpot containing a flower will always put the flower into your inventory.",
+  "carpet.rule.beeBreedingCooldown.desc": "Sets the cooldown for breeding bees (in ticks).",
   "carpet.rule.creativePlayerOneHitKill.desc": "Allows players in Creative mode to kill entities in one hit. This only works on non-player entities",
   "carpet.rule.disableMobSpawningInEnd.desc": "Disables mobs from spawning in the End.",
   "carpet.rule.disableMobSpawningInNether.desc": "Disables mobs from spawning in the Nether.",

--- a/src/main/resources/carpet-addons-not-found.mixins.json
+++ b/src/main/resources/carpet-addons-not-found.mixins.json
@@ -3,6 +3,7 @@
   "package": "carpetaddonsnotfound.mixins",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "AnimalEntityMixin",
     "DispenserBlockMixin",
     "EnderDragonFightMixin",
     "EnderEyeItemMixin",


### PR DESCRIPTION
Adds the carpet rule `beeBreedingCooldown` which allows you to set how many ticks must occur before a bee can be used for breeding again.

Closes #217 