### PR TITLE
Add rule `placeSugarCaneWithoutWater`

### DIFF
--- a/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
+++ b/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
@@ -83,6 +83,11 @@ public class CarpetAddonsNotFoundSettings {
   @CarpetAddonsNotFoundRule(categories = { FEATURE })
   public static boolean phantomsObeyHostileMobCap = false;
 
+  //#if MC>11802
+  @CarpetAddonsNotFoundRule(categories = { FEATURE, SURVIVAL })
+  public static boolean placeSugarCaneWithoutWater = false;
+  //#endif
+
   @CarpetAddonsNotFoundRule(categories = { FEATURE, SURVIVAL })
   public static ReplaceableFlowersOptions replaceableFlowers = ReplaceableFlowersOptions.FALSE;
 

--- a/src/main/java/carpetaddonsnotfound/mixins/SugarCaneBlockMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/SugarCaneBlockMixin.java
@@ -1,0 +1,34 @@
+package carpetaddonsnotfound.mixins;
+
+import net.minecraft.block.SugarCaneBlock;
+import org.spongepowered.asm.mixin.Mixin;
+
+//#if MC>11802
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldView;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.placeSugarCaneWithoutWater;
+//#endif
+
+@Mixin(SugarCaneBlock.class)
+public abstract class SugarCaneBlockMixin {
+  //#if MC>11802
+  @Inject(method = "canPlaceAt",
+          at = @At("HEAD"),
+          cancellable = true)
+  private void canPlaceOnMudBlock(
+          BlockState state,
+          WorldView world,
+          BlockPos pos,
+          CallbackInfoReturnable<Boolean> cir) {
+    BlockState blockStateBelow = world.getBlockState(pos.down());
+    if (placeSugarCaneWithoutWater && blockStateBelow.isOf(Blocks.MUD))
+      cir.setReturnValue(true);
+  }
+  //#endif
+}

--- a/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
+++ b/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
@@ -25,6 +25,8 @@
   "carpet.rule.netherWater.desc": "A charged creeper blowing up ice in the nether creates a water source.",
   "carpet.rule.passiveEndermen.desc": "Endermen will not be provoked by the player when attacked or looked at. They will still be provoked by other mobs.",
   "carpet.rule.phantomsObeyHostileMobCap.desc": "Phantoms will no longer spawn if the hostile mobcap is full. This is per player.",
+  "carpet.rule.placeSugarCaneWithoutWater.desc": "Sugarcane can be placed on mudblocks without adjacent water sources.",
+  "carpet.rule.placeSugarCaneWithoutWater.extra.0": "Only usable in Minecraft 1.19+",
   "carpet.rule.replaceableFlowers.desc": "Placing blocks on flowers will replace them like grass.",
   "carpet.rule.replaceFlowersInPots.desc": "Right clicking a flower pot with a flower will replace the flower that's in the pot with the one in the players hand",
   "carpet.rule.replaceMyceliumWithGrass.desc": "Bonemealing a grass block will replace adjacent mycelium blocks similar to how moss spreads to stone/deepslate when bonemealed.",

--- a/src/main/resources/carpet-addons-not-found.mixins.json
+++ b/src/main/resources/carpet-addons-not-found.mixins.json
@@ -22,6 +22,7 @@
     "SpawnEggItemMixin",
     "SpawnHelperMixin",
     "StonecutterBlockMixin",
+    "SugarCaneBlockMixin",
     "TallFlowerBlockMixin",
     "VegetationPatchFeatureMixin",
     "accessors.CreeperEntityAccessor",


### PR DESCRIPTION
Adds the carpet rule `placeSugarCaneWithoutWater` which allows placing Sugar Cane on a mud block without the need for a water source.

Closes #192 