### PR TITLE
Add rule `disableSpidersClimbingWalls`

### DIFF
--- a/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
+++ b/src/main/java/carpetaddonsnotfound/CarpetAddonsNotFoundSettings.java
@@ -34,6 +34,9 @@ public class CarpetAddonsNotFoundSettings {
   @CarpetAddonsNotFoundRule(categories = { FEATURE })
   public static boolean disablePhantomSpawningInMushroomFields = false;
 
+  @CarpetAddonsNotFoundRule(categories = { FEATURE })
+  public static boolean disableSpidersClimbingWalls = false;
+
   @CarpetAddonsNotFoundRule(categories = { FEATURE, DISPENSER })
   public static boolean dispensersPlaceEyesOfEnder = false;
 

--- a/src/main/java/carpetaddonsnotfound/mixins/SpiderEntityMixin.java
+++ b/src/main/java/carpetaddonsnotfound/mixins/SpiderEntityMixin.java
@@ -1,0 +1,21 @@
+package carpetaddonsnotfound.mixins;
+
+import net.minecraft.entity.mob.SpiderEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import static carpetaddonsnotfound.CarpetAddonsNotFoundSettings.disableSpidersClimbingWalls;
+
+@Mixin(SpiderEntity.class)
+public abstract class SpiderEntityMixin {
+  @ModifyVariable(method = "setClimbingWall",
+                  at = @At("HEAD"),
+                  argsOnly = true)
+  private boolean modifyClimbingBoolean(boolean climbing) {
+    if (disableSpidersClimbingWalls)
+      return false;
+
+    return climbing;
+  }
+}

--- a/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
+++ b/src/main/resources/assets/carpet-addons-not-found/lang/en_us.json
@@ -9,6 +9,7 @@
   "carpet.rule.disableEndSpikeRegen.desc": "Disables the regeneration of the end spike obsidian towers when the ender dragon is respawned.",
   "carpet.rule.disablePhantomSpawningForCreativePlayers.desc": "Phantoms will no longer spawn for creative players.",
   "carpet.rule.disablePhantomSpawningInMushroomFields.desc": "Phantoms will no longer spawn around a player that is in a mushroom fields biome.",
+  "carpet.rule.disableSpidersClimbingWalls.desc": "Spiders will no longer attempt to climb walls",
   "carpet.rule.dispensersPlaceEyesOfEnder.desc": "Dispensers can place eyes of ender into end portal frames.",
   "carpet.rule.dispensersRemoveEyesOfEnder.desc": "Dispensers can remove eyes of ender from full end portal frames. Any connecting end portals will break.",
   "carpet.rule.dropAllXpOnPlayerDeath.desc": "When a player dies, all of their XP will be dropped.",

--- a/src/main/resources/carpet-addons-not-found.mixins.json
+++ b/src/main/resources/carpet-addons-not-found.mixins.json
@@ -21,6 +21,7 @@
     "ServerChunkManagerMixin",
     "SpawnEggItemMixin",
     "SpawnHelperMixin",
+    "SpiderEntityMixin",
     "StonecutterBlockMixin",
     "SugarCaneBlockMixin",
     "TallFlowerBlockMixin",


### PR DESCRIPTION
Adds the carpet rule `disableSpidersClimbingWalls` which, as the name suggests, disables the spiders climbing on walls feature.

Closes #141 